### PR TITLE
Attempt adding floatmin2 to get poisson running

### DIFF
--- a/src/TrackedFloat.jl
+++ b/src/TrackedFloat.jl
@@ -74,7 +74,7 @@ for TrackedFloatN in (:TrackedFloat16, :TrackedFloat32, :TrackedFloat64)
     end
 
     # Hack to appease type dispatch
-    for NumType in (:Number, :Integer, :Float16, :Float32, :Float64)
+    for NumType in (:Bool, :Number, :Integer, :Float16, :Float32, :Float64)
       @eval function Base.$O(x::$NumType, y::$TrackedFloatN)
         (r, injected) = run_or_inject($O, [x, y.val])
         check_error($O, [x, y.val], r, injected)


### PR DESCRIPTION
I'm trying to get the `examples/finch/example-poisson1d.jl` running. I think we need to add some support for more functions in FloatTracker. I've added what I can, but I'm stuck at this point.

The error:

```
ERROR: LoadError: DomainError with -485:
Cannot raise an integer x to a negative power -485.
Convert input to float.
Stacktrace:
  [1] throw_domerr_powbysq(#unused#::TrackedFloat64, p::Int64)
    @ Base ./intfuncs.jl:251
  [2] power_by_squaring(x_::TrackedFloat64, p::Int64)
    @ Base ./intfuncs.jl:275
  [3] ^
    @ ./intfuncs.jl:300 [inlined]
  [4] floatmin2(#unused#::Type{TrackedFloat64})
    @ LinearAlgebra ~/.asdf/installs/julia/1.8.5/share/julia/stdlib/v1.8/LinearAlgebra/src/givens.jl:67
  [5] givensAlgorithm(f::TrackedFloat64, g::TrackedFloat64)
    @ LinearAlgebra ~/.asdf/installs/julia/1.8.5/share/julia/stdlib/v1.8/LinearAlgebra/src/givens.jl:82
    
… Lots of frames elided …
```

The line in question in `givens.jl`:

``` julia
floatmin2(::Type{Float32}) = reinterpret(Float32, 0x26000000)
floatmin2(::Type{Float64}) = reinterpret(Float64, 0x21a0000000000000)
floatmin2(::Type{T}) where {T} = (twopar = 2one(T); twopar^trunc(Integer,log(floatmin(T)/eps(T))/log(twopar)/twopar))
```

If we could just define that… thing… (is it a function? I'm not familiar with this syntax) for TrackedFloats, we'll be making more progress!

The other option is to figure out what's going on with the complex `twopar^trunc(…)` thing and why its not working for TrackedFloat.